### PR TITLE
Added new R&R:I leather items to Sewing Kit repair. 

### DIFF
--- a/RepairTools.dfmod.json
+++ b/RepairTools.dfmod.json
@@ -1,9 +1,9 @@
 {
     "ModTitle": "RepairTools",
-    "ModVersion": "1.08",
+    "ModVersion": "1.09",
     "ModAuthor": "Kirk.O",
     "ContactInfo": "kirkoliveri@gmail.com",
-    "DFUnity_Version": "0.10.26",
+    "DFUnity_Version": "0.11.1",
     "ModDescription": "Adds Repair Items To Fix Item Condition In The Field",
     "GUID": "968f2200-a351-4052-b9d5-4ee499a2b6bb",
     "Files": [

--- a/Scripts/ItemsRepairTools.cs
+++ b/Scripts/ItemsRepairTools.cs
@@ -94,10 +94,28 @@ namespace RepairTools
 
         public override bool IsValidForRepair(DaggerfallUnityItem item)
         {
-            return !item.IsEnchanted && !item.IsArtifact &&
-                ((item.ItemGroup == ItemGroups.Armor && item.NativeMaterialValue == (int)ArmorMaterialTypes.Leather) ||
-                item.ItemGroup == ItemGroups.MensClothing || item.ItemGroup == ItemGroups.WomensClothing ||
-                item.TemplateIndex == 530); // Item Index for Climates and Calories Camping Equipment item, so can repair the tent item now pretty much.
+            if (RepairTools.restrictedMaterialsCheck)
+            {
+                // This is using knowledge of the R&R:Items internals and may break if that mod ever changes.
+                return !item.IsEnchanted && !item.IsArtifact
+                    && (item.ItemGroup == ItemGroups.Armor
+                        && item.NativeMaterialValue >= (int)ArmorMaterialTypes.Leather
+                        && item.NativeMaterialValue <= (int)ArmorMaterialTypes.Adamantium - 0x200
+                    || item.ItemGroup == ItemGroups.MensClothing
+                    || item.ItemGroup == ItemGroups.WomensClothing
+                    || item.TemplateIndex == 530);
+            }
+            else
+            {
+                // This is using knowledge of the R&R:Items internals and may break if that mod ever changes.
+                return !item.IsEnchanted && !item.IsArtifact
+                    && (item.ItemGroup == ItemGroups.Armor
+                        && item.NativeMaterialValue >= (int)ArmorMaterialTypes.Leather
+                        && item.NativeMaterialValue <= (int)ArmorMaterialTypes.Daedric - 0x200
+                    || item.ItemGroup == ItemGroups.MensClothing
+                    || item.ItemGroup == ItemGroups.WomensClothing
+                    || item.TemplateIndex == 530);
+            }
         }
 
         public override int GetRepairPercentage(int luckMod, DaggerfallUnityItem itemToRepair)
@@ -193,19 +211,17 @@ namespace RepairTools
 
         public override bool IsValidForRepair(DaggerfallUnityItem item)
         {
-
             if (RepairTools.restrictedMaterialsCheck)
             {
                 // This is using knowledge of the R&R:Items internals and may break if that mod ever changes.
                 return !item.IsEnchanted && !item.IsArtifact && item.ItemGroup == ItemGroups.Armor &&
-                    item.NativeMaterialValue >= (int)ArmorMaterialTypes.Chain && item.NativeMaterialValue < (int)ArmorMaterialTypes.Adamantium - 100 &&
-                    !((int)item.dyeColor == 25 || (int)item.dyeColor == 24 || (int)item.dyeColor == 23);
+                    item.NativeMaterialValue >= (int)ArmorMaterialTypes.Chain && item.NativeMaterialValue <= (int)ArmorMaterialTypes.Adamantium - 0x100;
             }
             else
             {
                 // This is using knowledge of the R&R:Items internals and may break if that mod ever changes.
                 return !item.IsEnchanted && !item.IsArtifact && item.ItemGroup == ItemGroups.Armor && item.NativeMaterialValue >= (int)ArmorMaterialTypes.Chain &&
-                    item.NativeMaterialValue < (int)ArmorMaterialTypes.Adamantium - 100;
+                    item.NativeMaterialValue <= (int)ArmorMaterialTypes.Daedric - 0x100;
             }
         }
 


### PR DESCRIPTION
Also fixed Pliers accidentally using "- 100" instead of "- 0x100", and using "<" rather than "<=".

Tested using `add_all_equip armor` with both material restrictions on and off. On only repairs up to adamantium, off repairs all.