### PR TITLE
Fixed repair tools not being thrown away when broken

### DIFF
--- a/Scripts/AbstractItemRepairTools.cs
+++ b/Scripts/AbstractItemRepairTools.cs
@@ -129,7 +129,7 @@ namespace RepairTools
                     itemToRepair.currentCondition += repairAmount;
                 }
                 bool toolBroke = currentCondition <= DurabilityLoss;
-                LowerCondition(DurabilityLoss, playerEntity, repairItemCollection); // Damages repair tool condition.
+                LowerConditionWorkaround(DurabilityLoss, playerEntity, repairItemCollection); // Damages repair tool condition.
 
                 // Force inventory window update
                 DaggerfallUI.Instance.InventoryWindow.Refresh();
@@ -138,6 +138,18 @@ namespace RepairTools
                 playerEntity.DecreaseFatigue(staminaDrainValue, true); // Reduce player current stamina value from the action of repairing.
                 DaggerfallUnity.Instance.WorldTime.Now.RaiseTime(TimeDrainValue); // Forwards time by an amount of minutes in-game time.
                 ShowCustomTextBox(toolBroke, itemToRepair, false); // Shows the specific text-box after repairing an item.
+            }
+        }
+
+        // Like DaggerfallUnityItem's LowerCondition, but without taking DaggerfallUnity.Settings.AllowMagicRepairs into account
+        public void LowerConditionWorkaround(int amount, DaggerfallEntity unequipFromOwner = null, ItemCollection removeFromCollectionWhenBreaks = null)
+        {
+            currentCondition -= amount;
+            if (currentCondition <= 0)
+            {
+                currentCondition = 0;
+                ItemBreaks(unequipFromOwner);
+                removeFromCollectionWhenBreaks.RemoveItem(this);
             }
         }
 


### PR DESCRIPTION
Fixed repair tools not being thrown away when broken if DaggerfallUnity.Settings.AllowMagicRepairs is enabled